### PR TITLE
Add support for some common reserved second-level domains

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -192,6 +192,29 @@ function generatePassword() {
 	inputs.generatedPassword.value = password;
 }
 
+/**
+ * Get the main part of the domain, factoring in very common 2-level 'TLDs' where we need 3 rather than 2 parts.
+ *
+ * @param {string} host
+ * @return {string}
+ */
+function extractMainDomain(host) {
+  /**
+	 * @type {string[]} Define common reserved 2nd-level domains ONLY used at the 3rd and below level.
+   */
+	var commonTwoLevels = ['com.au', 'co.uk', 'ltd.uk', 'me.uk', 'net.uk', 'org.uk', 'plc.uk', 'sch.uk'];
+	var commonTwoLevelsPattern = commonTwoLevels
+		.map(twoLevelPart => ('\\.' + twoLevelPart.replace('.', '\\.'))) 	// Regex-escape dots + add leading ones
+		.join('|');																												// Or-ify the list of regex pieces
+  commonTwoLevelsPattern = '(' + commonTwoLevelsPattern + ')$'; 			// Build a complete end-matching regex
+
+	if (host.match(new RegExp(commonTwoLevelsPattern))) {
+    return host.split('.').slice(-3).join('.');
+	}
+
+  return host.split('.').slice(-2).join('.')
+}
+
 function initUi() {
 	var generatePasswordDebounced = debounce(generatePassword, 300);
 	var generateUnicornpassDebounced = debounce(generateUnicornpass, 300);
@@ -288,7 +311,7 @@ function initUi() {
 
 			var host = parseUrl(tab.url).hostname;
 			if (prefs.urlComponents == 'domain' && !ipRegex.test(host)) {
-				host = host.split('.').slice(-2).join('.');
+				host = extractMainDomain(host);
 			}
 			inputs.domain.value = host;
 

--- a/js/popup.js
+++ b/js/popup.js
@@ -199,20 +199,20 @@ function generatePassword() {
  * @return {string}
  */
 function extractMainDomain(host) {
-  /**
+	/**
 	 * @type {string[]} Define common reserved 2nd-level domains ONLY used at the 3rd and below level.
-   */
+	 */
 	var commonTwoLevels = ['com.au', 'co.uk', 'ltd.uk', 'me.uk', 'net.uk', 'org.uk', 'plc.uk', 'sch.uk'];
 	var commonTwoLevelsPattern = commonTwoLevels
 		.map(twoLevelPart => ('\\.' + twoLevelPart.replace('.', '\\.'))) 	// Regex-escape dots + add leading ones
-		.join('|');																												// Or-ify the list of regex pieces
-  commonTwoLevelsPattern = '(' + commonTwoLevelsPattern + ')$'; 			// Build a complete end-matching regex
+		.join('|');                                                     	// Or-ify the list of regex pieces
+	commonTwoLevelsPattern = '(' + commonTwoLevelsPattern + ')$';     	// Build a complete end-matching regex
 
 	if (host.match(new RegExp(commonTwoLevelsPattern))) {
-    return host.split('.').slice(-3).join('.');
+		return host.split('.').slice(-3).join('.');
 	}
 
-  return host.split('.').slice(-2).join('.')
+	return host.split('.').slice(-2).join('.')
 }
 
 function initUi() {

--- a/js/popup.js
+++ b/js/popup.js
@@ -203,13 +203,10 @@ function extractMainDomain(host) {
 	 * @type {string[]} Define common reserved 2nd-level domains ONLY used at the 3rd and below level.
 	 */
 	var commonTwoLevels = ['com.au', 'co.uk', 'ltd.uk', 'me.uk', 'net.uk', 'org.uk', 'plc.uk', 'sch.uk'];
-	var commonTwoLevelsPattern = commonTwoLevels
-		.map(twoLevelPart => ('\\.' + twoLevelPart.replace('.', '\\.'))) 	// Regex-escape dots + add leading ones
-		.join('|');                                                     	// Or-ify the list of regex pieces
-	commonTwoLevelsPattern = '(' + commonTwoLevelsPattern + ')$';     	// Build a complete end-matching regex
-
-	if (host.match(new RegExp(commonTwoLevelsPattern))) {
-		return host.split('.').slice(-3).join('.');
+	for (var index in commonTwoLevels) {
+		if (host.endsWith('.' + commonTwoLevels[index])) {
+			return host.split('.').slice(-3).join('.');
+		}
 	}
 
 	return host.split('.').slice(-2).join('.')


### PR DESCRIPTION
Fixes https://github.com/emersion/passwordmaker/issues/11

This brings behaviour in line with other common PasswordMaker algorithm front-ends for:
* all common _.uk_ second-levels that are available for public registration; and
* _com.au_

The main list is a simple string array so that adding more is simple.